### PR TITLE
Add image gathering to both spiders

### DIFF
--- a/rossimages/items.py
+++ b/rossimages/items.py
@@ -6,7 +6,8 @@
 import scrapy
 
 
-class RossimagesItem(scrapy.Item):
+class ImageItem(scrapy.Item):
     # define the fields for your item here like:
     # name = scrapy.Field()
-    pass
+    image_urls = scrapy.Field()
+    images = scrapy.Field()

--- a/rossimages/settings.py
+++ b/rossimages/settings.py
@@ -25,7 +25,7 @@ ROBOTSTXT_OBEY = True
 # Configure a delay for requests for the same website (default: 0)
 # See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-# DOWNLOAD_DELAY = 3
+DOWNLOAD_DELAY = 1.5
 # The download delay setting will honor only one of:
 # CONCURRENT_REQUESTS_PER_DOMAIN = 16
 # CONCURRENT_REQUESTS_PER_IP = 16
@@ -65,7 +65,7 @@ ROBOTSTXT_OBEY = True
 ITEM_PIPELINES = {
     "scrapy.pipelines.images.ImagesPipeline": 1,
 }
-IMAGES_STORE = "../images"
+IMAGES_STORE = "images"
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html

--- a/rossimages/spiders/community.py
+++ b/rossimages/spiders/community.py
@@ -1,4 +1,5 @@
 import scrapy
+from rossimages.items import ImageItem
 
 
 class CommunitySpider(scrapy.Spider):
@@ -7,16 +8,13 @@ class CommunitySpider(scrapy.Spider):
     start_urls = ["https://www.twoinchbrush.com/fanpaintings"]
 
     def parse(self, response):
-        filename = "community.html"
-        with open(filename, "wb") as f:
-            f.write(response.body)
-        self.log(f"Saved file {filename}")
+        URL_PREFIX = "https://www.twoinchbrush.com"
+        for source in response.xpath(
+            "//a[not(@target='_blank')]//div[@class='progressive replace']/@data-img"
+        ).getall():
+            yield ImageItem(image_urls=[f"{URL_PREFIX}{source}"])
 
         # Recursively crawl the next page and parse the images.
-        # yield from response.follow_all(
-        #     xpath="//ul[@class='pagination']//a[@rel='next']", callback=self.parse
-        # )
-
-
-# Get non-ad images from Two-Inch Brush.
-# response.xpath("//a[not(@target='_blank')]//img/@src").get()
+        yield from response.follow_all(
+            xpath="//ul[@class='pagination']//a[@rel='next']", callback=self.parse
+        )

--- a/rossimages/spiders/ross.py
+++ b/rossimages/spiders/ross.py
@@ -1,13 +1,20 @@
 import scrapy
+from rossimages.items import ImageItem
 
 
 class RossSpider(scrapy.Spider):
     name = "ross"
     allowed_domains = ["www.twoinchbrush.com"]
-    start_urls = ["http://www.twoinchbrush.com/"]
+    start_urls = ["http://www.twoinchbrush.com/all-paintings"]
 
     def parse(self, response):
-        filename = "ross.html"
-        with open(filename, "wb") as f:
-            f.write(response.body)
-        self.log(f"saved file{filename}")
+        URL_PREFIX = "https://www.twoinchbrush.com"
+        for source in response.xpath(
+            "//a[not(@target='_blank')]//div[@class='progressive replace']/@data-img"
+        ).getall():
+            yield ImageItem(image_urls=[f"{URL_PREFIX}{source}"])
+
+        # Recursively crawl the next page and parse the images.
+        yield from response.follow_all(
+            xpath="//ul[@class='pagination']//a[@rel='next']", callback=self.parse
+        )


### PR DESCRIPTION
This PR enables the spiders to gather Ross original and community Ross reproductions using scrapy's built-in `ImagePipeline`. It also introduces a variable delay of 750 ms to 3 s per image to prevent overloading the server(s).